### PR TITLE
Decouple tests from default theme widgets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "wp-cli/wp-cli": "^2.5"
     },
     "require-dev": {
+        "wp-cli/db-command": "^2.0",
         "wp-cli/extension-command": "^1.2 || ^2",
         "wp-cli/wp-cli-tests": "^3.0.11"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "wp-cli/wp-cli": "^2.5"
     },
     "require-dev": {
-        "wp-cli/db-command": "^2.0",
         "wp-cli/extension-command": "^1.2 || ^2",
         "wp-cli/wp-cli-tests": "^3.0.11"
     },

--- a/features/widget-reset.feature
+++ b/features/widget-reset.feature
@@ -1,12 +1,14 @@
 Feature: Reset WordPress sidebars
 
-  Scenario: Reset sidebar
+  Background:
     Given a WP install
-
-    When I try `wp theme delete twentytwelve --force`
+    And I try `wp theme delete twentytwelve --force`
     And I run `wp theme install twentytwelve --activate`
-    Then STDOUT should not be empty
-    And the return code should be 0
+    And I try `wp widget reset --all`
+    And I try `wp widget delete wp_inactive_widgets $(wp widget list wp_inactive_widgets --format=ids)`
+
+  Scenario: Reset sidebar
+    Given I run `wp widget add text sidebar-1 --title="Text"`
 
     When I run `wp widget list sidebar-1 --format=count`
     # The count should be non-zero (= the sidebar contains widgets)
@@ -81,13 +83,6 @@ Feature: Reset WordPress sidebars
       """
 
   Scenario: Reset all sidebars
-    Given a WP install
-
-    When I try `wp theme delete twentytwelve --force`
-    And I run `wp theme install twentytwelve --activate`
-    Then STDOUT should not be empty
-    And the return code should be 0
-
     When I run `wp widget add calendar sidebar-1 --title="Calendar"`
     Then STDOUT should not be empty
     When I run `wp widget add search sidebar-2 --title="Quick Search"`
@@ -123,49 +118,18 @@ Feature: Reset WordPress sidebars
     When I run `wp widget list wp_inactive_widgets --format=ids`
     Then STDOUT should contain:
       """
-      text-1
-      """
-    Then STDOUT should contain:
-      """
-      search-3
-      """
-    Then STDOUT should contain:
-      """
-      meta-2
-      """
-    Then STDOUT should contain:
-      """
-      categories-2
-      """
-    Then STDOUT should contain:
-      """
-      archives-2
-      """
-    Then STDOUT should contain:
-      """
-      recent-comments-2
-      """
-    Then STDOUT should contain:
-      """
-      recent-posts-2
-      """
-    Then STDOUT should contain:
-      """
-      search-2
-      """
-    Then STDOUT should contain:
-      """
       calendar-1
+      """
+    Then STDOUT should contain:
+      """
+      search-1
+      """
+    Then STDOUT should contain:
+      """
+      text-1
       """
 
   Scenario: Testing movement of widgets while reset
-    Given a WP install
-
-    When I try `wp theme delete twentytwelve --force`
-    And I run `wp theme install twentytwelve --activate`
-    Then STDOUT should not be empty
-    And the return code should be 0
-
     When I run `wp widget add calendar sidebar-2 --title="Calendar"`
     Then STDOUT should not be empty
     And I run `wp widget add search sidebar-2 --title="Quick Search"`
@@ -174,7 +138,7 @@ Feature: Reset WordPress sidebars
     When I run `wp widget list sidebar-2 --format=ids`
     Then STDOUT should contain:
       """
-      search-3 calendar-1
+      search-1 calendar-1
       """
     When I run `wp widget list wp_inactive_widgets --format=ids`
     Then STDOUT should be empty
@@ -185,5 +149,5 @@ Feature: Reset WordPress sidebars
     And I run `wp widget list wp_inactive_widgets --format=ids`
     Then STDOUT should contain:
       """
-      calendar-1 search-3
+      calendar-1 search-1
       """

--- a/features/widget.feature
+++ b/features/widget.feature
@@ -2,37 +2,45 @@ Feature: Manage widgets in WordPress sidebar
 
   Background:
     Given a WP install
-    When I run `wp theme install p2 --activate`
-    Then STDOUT should not be empty
+    And I try `wp theme delete twentytwelve --force`
+    And I run `wp theme install twentytwelve --activate`
+    And I try `wp widget reset --all`
+    And I try `wp widget delete wp_inactive_widgets $(wp widget list wp_inactive_widgets --format=ids)`
+    And I run `wp widget add text sidebar-1 --title="Text 1"`
+    And I run `wp widget add archives sidebar-1 --title="Archives"`
+    And I run `wp widget add calendar sidebar-1 --title="Calendar"`
+    And I run `wp widget add search sidebar-1 --title="Quick Search"`
+    And I run `wp widget add text sidebar-1 --title="Text 2"`
+    And I run `wp widget add search sidebar-2 --title="Quick Search"`
+    And I run `wp widget add text sidebar-3 --title="Text"`
+
 
   Scenario: Widget CRUD
     When I run `wp widget list sidebar-1 --fields=name,id,position`
     Then STDOUT should be a table containing rows:
-      | name            | id                | position |
-      | search          | search-2          | 1        |
-      | recent-posts    | recent-posts-2    | 2        |
-      | recent-comments | recent-comments-2 | 3        |
-      | archives        | archives-2        | 4        |
-      | categories      | categories-2      | 5        |
-      | meta            | meta-2            | 6        |
+      | name     | id         | position |
+      | text     | text-2     | 1        |
+      | search   | search-1   | 2        |
+      | calendar | calendar-1 | 3        |
+      | archives | archives-1 | 4        |
+      | text     | text-1     | 5        |
 
-    When I run `wp widget move recent-comments-2 --position=2`
+    When I run `wp widget move archives-1 --position=2`
     Then STDOUT should not be empty
 
     When I run `wp widget list sidebar-1 --fields=name,id,position`
     Then STDOUT should be a table containing rows:
-      | name            | id                | position |
-      | search          | search-2          | 1        |
-      | recent-comments | recent-comments-2 | 2        |
-      | recent-posts    | recent-posts-2    | 3        |
-      | archives        | archives-2        | 4        |
-      | categories      | categories-2      | 5        |
-      | meta            | meta-2            | 6        |
+      | name     | id         | position |
+      | text     | text-2     | 1        |
+      | archives | archives-1 | 2        |
+      | search   | search-1   | 3        |
+      | calendar | calendar-1 | 4        |
+      | text     | text-1     | 5        |
 
-    When I run `wp widget move recent-comments-2 --sidebar-id=wp_inactive_widgets`
+    When I run `wp widget move text-2 --sidebar-id=wp_inactive_widgets`
     Then STDOUT should not be empty
 
-    When I run `wp widget deactivate meta-2`
+    When I run `wp widget deactivate calendar-1`
     Then STDOUT should be:
       """
       Success: Deactivated 1 of 1 widgets.
@@ -42,19 +50,18 @@ Feature: Manage widgets in WordPress sidebar
 
     When I run `wp widget list sidebar-1 --fields=name,id,position`
     Then STDOUT should be a table containing rows:
-      | name            | id                | position |
-      | search          | search-2          | 1        |
-      | recent-posts    | recent-posts-2    | 2        |
-      | archives        | archives-2        | 3        |
-      | categories      | categories-2      | 4        |
+      | name     | id         | position |
+      | archives | archives-1 | 1        |
+      | search   | search-1   | 2        |
+      | text     | text-1     | 3        |
 
     When I run `wp widget list wp_inactive_widgets --fields=name,id,position`
     Then STDOUT should be a table containing rows:
-      | name            | id                | position |
-      | meta            | meta-2            | 1        |
-      | recent-comments | recent-comments-2 | 2        |
+      | name     | id         | position |
+      | calendar | calendar-1 | 1        |
+      | text     | text-2     | 2        |
 
-    When I run `wp widget delete archives-2 recent-posts-2`
+    When I run `wp widget delete archives-1 text-2`
     Then STDOUT should be:
       """
       Success: Deleted 2 of 2 widgets.
@@ -64,33 +71,38 @@ Feature: Manage widgets in WordPress sidebar
 
     When I run `wp widget list sidebar-1 --fields=name,id,position`
     Then STDOUT should be a table containing rows:
-      | name            | id                | position |
-      | search          | search-2          | 1        |
-      | categories      | categories-2      | 2        |
+      | name     | id         | position |
+      | search   | search-1   | 1        |
+      | text     | text-1     | 2        |
 
-    When I run `wp widget add calendar sidebar-1 2`
+    When I run `wp widget add archives sidebar-1 2 --title="Archives"`
     Then STDOUT should not be empty
 
     When I run `wp widget list sidebar-1 --fields=name,id,position`
     Then STDOUT should be a table containing rows:
-      | name            | id                | position |
-      | search          | search-2          | 1        |
-      | calendar        | calendar-1        | 2        |
-      | categories      | categories-2      | 3        |
+      | name     | id         | position |
+      | search   | search-1   | 1        |
+      | archives | archives-1 | 2        |
+      | text     | text-1     | 3        |
 
     When I run `wp widget list sidebar-1 --format=ids`
     Then STDOUT should be:
       """
-      search-2 calendar-1 categories-2
+      search-1 archives-1 text-1
       """
 
-    When I run `wp widget update calendar-1 --title="Calendar"`
+    When I run `wp widget list sidebar-1 --fields=name,position,options`
+    Then STDOUT should be a table containing rows:
+      | name     | position | options                                     |
+      | archives | 2        | {"title":"Archives","count":0,"dropdown":0} |
+
+    When I run `wp widget update archives-1 --title="New Archives"`
     Then STDOUT should not be empty
 
     When I run `wp widget list sidebar-1 --fields=name,position,options`
     Then STDOUT should be a table containing rows:
-      | name            | position | options               |
-      | calendar        | 2        | {"title":"Calendar"}  |
+      | name     | position | options                                         |
+      | archives | 2        | {"title":"New Archives","count":0,"dropdown":0} |
 
   Scenario: Validate sidebar widgets
     When I try `wp widget update calendar-999`
@@ -108,7 +120,7 @@ Feature: Manage widgets in WordPress sidebar
     And the return code should be 1
 
   Scenario: Return code is 0 when all widgets exist, deactivation
-    When I run `wp widget deactivate recent-posts-2`
+    When I run `wp widget deactivate text-1`
     Then STDOUT should be:
       """
       Success: Deactivated 1 of 1 widgets.
@@ -116,7 +128,7 @@ Feature: Manage widgets in WordPress sidebar
     And STDERR should be empty
     And the return code should be 0
 
-    When I run `wp widget deactivate search-2 archives-2`
+    When I run `wp widget deactivate archives-1 calendar-1`
     Then STDOUT should be:
       """
       Success: Deactivated 2 of 2 widgets.
@@ -125,7 +137,7 @@ Feature: Manage widgets in WordPress sidebar
     And the return code should be 0
 
   Scenario: Return code is 0 when all widgets exist, deletion
-    When I run `wp widget delete recent-posts-2`
+    When I run `wp widget delete text-1`
     Then STDOUT should be:
       """
       Success: Deleted 1 of 1 widgets.
@@ -133,7 +145,7 @@ Feature: Manage widgets in WordPress sidebar
     And STDERR should be empty
     And the return code should be 0
 
-    When I run `wp widget delete search-2 archives-2`
+    When I run `wp widget delete archives-1 calendar-1`
     Then STDOUT should be:
       """
       Success: Deleted 2 of 2 widgets.
@@ -150,7 +162,7 @@ Feature: Manage widgets in WordPress sidebar
       """
     And the return code should be 1
 
-    When I try `wp widget deactivate recent-posts-2 calendar-999`
+    When I try `wp widget deactivate text-1 calendar-999`
     Then STDERR should be:
       """
       Warning: Widget 'calendar-999' doesn't exist.
@@ -167,7 +179,7 @@ Feature: Manage widgets in WordPress sidebar
       """
     And the return code should be 1
 
-    When I try `wp widget delete recent-posts-2 calendar-999`
+    When I try `wp widget delete text-1 calendar-999`
     Then STDERR should be:
       """
       Warning: Widget 'calendar-999' doesn't exist.


### PR DESCRIPTION
Many widget tests have been breaking from one WP major release to the next because of widget changes in the default theme.

This PR tries to decouple the tests from whatever the default widget in the latest default theme happens to be.
