### PR TITLE
Append new widgets to the bottom of a sidebar

### DIFF
--- a/features/widget-reset.feature
+++ b/features/widget-reset.feature
@@ -138,7 +138,7 @@ Feature: Reset WordPress sidebars
     When I run `wp widget list sidebar-2 --format=ids`
     Then STDOUT should contain:
       """
-      search-1 calendar-1
+      calendar-1 search-1
       """
     When I run `wp widget list wp_inactive_widgets --format=ids`
     Then STDOUT should be empty

--- a/features/widget.feature
+++ b/features/widget.feature
@@ -61,7 +61,7 @@ Feature: Manage widgets in WordPress sidebar
       | text     | text-1     | 1        |
       | calendar | calendar-1 | 2        |
 
-    When I run `wp widget delete archives-1 text-2`
+    When I run `wp widget delete archives-1 text-1`
     Then STDOUT should be:
       """
       Success: Deleted 2 of 2 widgets.
@@ -88,7 +88,7 @@ Feature: Manage widgets in WordPress sidebar
     When I run `wp widget list sidebar-1 --format=ids`
     Then STDOUT should be:
       """
-      search-1 archives-1 text-1
+      search-1 archives-1 text-2
       """
 
     When I run `wp widget list sidebar-1 --fields=name,position,options`

--- a/features/widget.feature
+++ b/features/widget.feature
@@ -19,25 +19,25 @@ Feature: Manage widgets in WordPress sidebar
     When I run `wp widget list sidebar-1 --fields=name,id,position`
     Then STDOUT should be a table containing rows:
       | name     | id         | position |
-      | text     | text-2     | 1        |
-      | search   | search-1   | 2        |
+      | text     | text-1     | 1        |
+      | archives | archives-1 | 2        |
       | calendar | calendar-1 | 3        |
-      | archives | archives-1 | 4        |
-      | text     | text-1     | 5        |
+      | search   | search-1   | 4        |
+      | text     | text-2     | 5        |
 
-    When I run `wp widget move archives-1 --position=2`
+    When I run `wp widget move search-1 --position=2`
     Then STDOUT should not be empty
 
     When I run `wp widget list sidebar-1 --fields=name,id,position`
     Then STDOUT should be a table containing rows:
       | name     | id         | position |
-      | text     | text-2     | 1        |
-      | archives | archives-1 | 2        |
-      | search   | search-1   | 3        |
+      | text     | text-1     | 1        |
+      | search   | search-1   | 2        |
+      | archives | archives-1 | 3        |
       | calendar | calendar-1 | 4        |
-      | text     | text-1     | 5        |
+      | text     | text-2     | 5        |
 
-    When I run `wp widget move text-2 --sidebar-id=wp_inactive_widgets`
+    When I run `wp widget move text-1 --sidebar-id=wp_inactive_widgets`
     Then STDOUT should not be empty
 
     When I run `wp widget deactivate calendar-1`
@@ -51,15 +51,15 @@ Feature: Manage widgets in WordPress sidebar
     When I run `wp widget list sidebar-1 --fields=name,id,position`
     Then STDOUT should be a table containing rows:
       | name     | id         | position |
-      | archives | archives-1 | 1        |
-      | search   | search-1   | 2        |
-      | text     | text-1     | 3        |
+      | search   | search-1   | 1        |
+      | archives | archives-1 | 2        |
+      | text     | text-2     | 3        |
 
     When I run `wp widget list wp_inactive_widgets --fields=name,id,position`
     Then STDOUT should be a table containing rows:
       | name     | id         | position |
-      | calendar | calendar-1 | 1        |
-      | text     | text-2     | 2        |
+      | text     | text-1     | 1        |
+      | calendar | calendar-1 | 2        |
 
     When I run `wp widget delete archives-1 text-2`
     Then STDOUT should be:
@@ -73,7 +73,7 @@ Feature: Manage widgets in WordPress sidebar
     Then STDOUT should be a table containing rows:
       | name     | id         | position |
       | search   | search-1   | 1        |
-      | text     | text-1     | 2        |
+      | text     | text-2     | 2        |
 
     When I run `wp widget add archives sidebar-1 2 --title="Archives"`
     Then STDOUT should not be empty
@@ -83,7 +83,7 @@ Feature: Manage widgets in WordPress sidebar
       | name     | id         | position |
       | search   | search-1   | 1        |
       | archives | archives-1 | 2        |
-      | text     | text-1     | 3        |
+      | text     | text-2     | 3        |
 
     When I run `wp widget list sidebar-1 --format=ids`
     Then STDOUT should be:

--- a/src/Widget_Command.php
+++ b/src/Widget_Command.php
@@ -130,10 +130,13 @@ class Widget_Command extends WP_CLI_Command {
 	 * @subcommand add
 	 */
 	public function add( $args, $assoc_args ) {
-
 		list( $name, $sidebar_id ) = $args;
-		$position                  = Utils\get_flag_value( $args, 2, 1 ) - 1;
+
 		$this->validate_sidebar( $sidebar_id );
+
+		$position = count( $args ) > 2
+			? $args[2] - 1
+			: count( $this->get_sidebar_widgets( $sidebar_id ) );
 
 		$widget = $this->get_widget_obj( $name );
 		if ( false === $widget ) {
@@ -300,7 +303,13 @@ class Widget_Command extends WP_CLI_Command {
 				continue;
 			}
 
-			$this->move_sidebar_widget( $widget_id, $sidebar_id, 'wp_inactive_widgets', $sidebar_index, 0 );
+			$this->move_sidebar_widget(
+				$widget_id,
+				$sidebar_id,
+				'wp_inactive_widgets',
+				$sidebar_index,
+				count( $this->get_sidebar_widgets( 'wp_inactive_widgets' ) )
+			);
 
 			$count++;
 
@@ -427,7 +436,13 @@ class Widget_Command extends WP_CLI_Command {
 				foreach ( $widgets as $widget ) {
 					$widget_id = $widget->id;
 					list( $name, $option_index, $new_sidebar_id, $sidebar_index ) = $this->get_widget_data( $widget_id );
-					$this->move_sidebar_widget( $widget_id, $new_sidebar_id, 'wp_inactive_widgets', $sidebar_index, 0 );
+					$this->move_sidebar_widget(
+						$widget_id,
+						$new_sidebar_id,
+						'wp_inactive_widgets',
+						$sidebar_index,
+						count( $this->get_sidebar_widgets( 'wp_inactive_widgets' ) )
+					);
 				}
 				WP_CLI::log( sprintf( "Sidebar '%s' reset.", $sidebar_id ) );
 				$count++;


### PR DESCRIPTION
Instead of adding widgets at the top/front of a sidebar, add them at the bottom/end of a sidebar by default.

Fixes #43 