### PR TITLE
Extend wp sidebar command with additional subcommands

### DIFF
--- a/features/sidebar.feature
+++ b/features/sidebar.feature
@@ -26,3 +26,21 @@ Feature: Manage WordPress sidebars
       """
       4
       """
+
+  Scenario: Get sidebar details
+    Given a WP install
+    When I run `wp sidebar get sidebar-1`
+    Then STDOUT should contain:
+      """
+      sidebar-1
+      """
+
+  Scenario: Sidebar exists command returns success
+    Given a WP install
+    When I run `wp sidebar exists sidebar-1`
+    Then the return code should be 0
+
+  Scenario: Sidebar exists command returns failure
+    Given a WP install
+    When I run `wp sidebar exists does-not-exist`
+    Then the return code should be 1

--- a/src/Sidebar_Command.php
+++ b/src/Sidebar_Command.php
@@ -4,19 +4,21 @@ use WP_CLI\Utils;
 use WP_CLI\Formatter;
 
 /**
- * Manage registered sidebars.
+ * Lists registered sidebars.
  *
- * A [sidebar](https://developer.wordpress.org/themes/functionality/sidebars/)
- * is any widgetized area of your theme.
+ * A [sidebar](https://developer.wordpress.org/themes/functionality/sidebars/) is any widgetized area of your theme.
+ *
+ * ## EXAMPLES
+ *
+ *     # List sidebars
+ *     $ wp sidebar list --fields=name,id --format=csv
+ *     name,id
+ *     "Widget Area",sidebar-1
+ *     "Inactive Widgets",wp_inactive_widgets
  */
 class Sidebar_Command extends WP_CLI_Command {
 
-	/**
-	 * Default fields for sidebar output.
-	 *
-	 * @var array
-	 */
-	private $default_fields = [
+	private $fields = [
 		'name',
 		'id',
 		'description',
@@ -38,9 +40,9 @@ class Sidebar_Command extends WP_CLI_Command {
 	 *   - table
 	 *   - csv
 	 *   - json
-	 *   - yaml
 	 *   - ids
 	 *   - count
+	 *   - yaml
 	 * ---
 	 *
 	 * ## AVAILABLE FIELDS
@@ -61,40 +63,25 @@ class Sidebar_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp sidebar list
-	 *     $ wp sidebar list --fields=name,id
-	 *     $ wp sidebar list --format=ids
-	 *     $ wp sidebar list --format=count
+	 *     $ wp sidebar list --fields=name,id --format=csv
+	 *     name,id
+	 *     "Widget Area",sidebar-1
+	 *     "Inactive Widgets",wp_inactive_widgets
 	 *
 	 * @subcommand list
-	 * @when after_wp_load
 	 */
 	public function list_( $args, $assoc_args ) {
 		global $wp_registered_sidebars;
 
-		if ( function_exists( 'wp_register_unused_sidebar' ) ) {
-			Utils\wp_register_unused_sidebar();
+		Utils\wp_register_unused_sidebar();
+
+		if ( ! empty( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
+			$sidebars = wp_list_pluck( $wp_registered_sidebars, 'id' );
+		} else {
+			$sidebars = $wp_registered_sidebars;
 		}
 
-		// Filter out wp_inactive_widgets from the display
-		$sidebars = array_filter(
-			$wp_registered_sidebars,
-			function( $sidebar ) {
-				return 'wp_inactive_widgets' !== $sidebar['id'];
-			}
-		);
-
-		if ( isset( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
-			WP_CLI::line( implode( ' ', wp_list_pluck( $sidebars, 'id' ) ) );
-			return;
-		}
-
-		if ( isset( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {
-			WP_CLI::line( count( $sidebars ) );
-			return;
-		}
-
-		$formatter = new Formatter( $assoc_args, $this->default_fields );
+		$formatter = new Formatter( $assoc_args, $this->fields );
 		$formatter->display_items( $sidebars );
 	}
 
@@ -129,9 +116,7 @@ class Sidebar_Command extends WP_CLI_Command {
 	public function get( $args, $assoc_args ) {
 		global $wp_registered_sidebars;
 
-		if ( function_exists( 'wp_register_unused_sidebar' ) ) {
-			Utils\wp_register_unused_sidebar();
-		}
+		Utils\wp_register_unused_sidebar();
 
 		$id = $args[0];
 
@@ -139,7 +124,7 @@ class Sidebar_Command extends WP_CLI_Command {
 			WP_CLI::error( "Sidebar '{$id}' does not exist." );
 		}
 
-		$formatter = new Formatter( $assoc_args, $this->default_fields );
+		$formatter = new Formatter( $assoc_args, $this->fields );
 		$formatter->display_item( $wp_registered_sidebars[ $id ] );
 	}
 
@@ -161,78 +146,12 @@ class Sidebar_Command extends WP_CLI_Command {
 	public function exists( $args ) {
 		global $wp_registered_sidebars;
 
-		if ( function_exists( 'wp_register_unused_sidebar' ) ) {
-			Utils\wp_register_unused_sidebar();
-		}
+		Utils\wp_register_unused_sidebar();
 
 		if ( isset( $wp_registered_sidebars[ $args[0] ] ) ) {
 			WP_CLI::halt( 0 );
 		}
 
 		WP_CLI::halt( 1 );
-	}
-
-	/**
-	 * List widgets assigned to a sidebar.
-	 *
-	 * ## OPTIONS
-	 *
-	 * <id>
-	 * : The sidebar ID.
-	 *
-	 * [--format=<format>]
-	 * : Render output in a particular format.
-	 * ---
-	 * default: table
-	 * options:
-	 *   - table
-	 *   - csv
-	 *   - json
-	 *   - yaml
-	 *   - ids
-	 * ---
-	 *
-	 * ## EXAMPLES
-	 *
-	 *     $ wp sidebar widgets sidebar-1
-	 *     $ wp sidebar widgets wp_inactive_widgets --format=ids
-	 *
-	 * @when after_wp_load
-	 */
-	public function widgets( $args, $assoc_args ) {
-		global $wp_registered_sidebars;
-
-		if ( function_exists( 'wp_register_unused_sidebar' ) ) {
-			Utils\wp_register_unused_sidebar();
-		}
-
-		$id = $args[0];
-
-		if ( ! isset( $wp_registered_sidebars[ $id ] ) ) {
-			WP_CLI::error( "Sidebar '{$id}' does not exist." );
-		}
-
-		$sidebars_widgets = wp_get_sidebars_widgets();
-		$widget_ids       = isset( $sidebars_widgets[ $id ] ) ? $sidebars_widgets[ $id ] : [];
-
-		if ( empty( $widget_ids ) ) {
-			WP_CLI::warning( "No widgets found in sidebar '{$id}'." );
-			return;
-		}
-
-		if ( isset( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
-			WP_CLI::line( implode( ' ', $widget_ids ) );
-			return;
-		}
-
-		$items = array_map(
-			function ( $widget_id ) {
-				return [ 'id' => $widget_id ];
-			},
-			$widget_ids
-		);
-
-		$formatter = new Formatter( $assoc_args, [ 'id' ] );
-		$formatter->display_items( $items );
 	}
 }

--- a/src/Sidebar_Command.php
+++ b/src/Sidebar_Command.php
@@ -4,21 +4,19 @@ use WP_CLI\Utils;
 use WP_CLI\Formatter;
 
 /**
- * Lists registered sidebars.
+ * Manage registered sidebars.
  *
- * A [sidebar](https://developer.wordpress.org/themes/functionality/sidebars/) is any widgetized area of your theme.
- *
- * ## EXAMPLES
- *
- *     # List sidebars
- *     $ wp sidebar list --fields=name,id --format=csv
- *     name,id
- *     "Widget Area",sidebar-1
- *     "Inactive Widgets",wp_inactive_widgets
+ * A [sidebar](https://developer.wordpress.org/themes/functionality/sidebars/)
+ * is any widgetized area of your theme.
  */
 class Sidebar_Command extends WP_CLI_Command {
 
-	private $fields = [
+	/**
+	 * Default fields for sidebar output.
+	 *
+	 * @var array
+	 */
+	private $default_fields = [
 		'name',
 		'id',
 		'description',
@@ -40,48 +38,167 @@ class Sidebar_Command extends WP_CLI_Command {
 	 *   - table
 	 *   - csv
 	 *   - json
+	 *   - yaml
 	 *   - ids
 	 *   - count
-	 *   - yaml
 	 * ---
-	 *
-	 * ## AVAILABLE FIELDS
-	 *
-	 * These fields will be displayed by default for each sidebar:
-	 *
-	 * * name
-	 * * id
-	 * * description
-	 *
-	 * These fields are optionally available:
-	 *
-	 * * class
-	 * * before_widget
-	 * * after_widget
-	 * * before_title
-	 * * after_title
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     $ wp sidebar list --fields=name,id --format=csv
-	 *     name,id
-	 *     "Widget Area",sidebar-1
-	 *     "Inactive Widgets",wp_inactive_widgets
+	 *     $ wp sidebar list
+	 *     $ wp sidebar list --fields=name,id
+	 *     $ wp sidebar list --format=ids
+	 *     $ wp sidebar list --format=count
 	 *
 	 * @subcommand list
+	 * @when after_wp_load
 	 */
 	public function list_( $args, $assoc_args ) {
 		global $wp_registered_sidebars;
 
-		Utils\wp_register_unused_sidebar();
-
-		if ( ! empty( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
-			$sidebars = wp_list_pluck( $wp_registered_sidebars, 'id' );
-		} else {
-			$sidebars = $wp_registered_sidebars;
+		if ( function_exists( 'wp_register_unused_sidebar' ) ) {
+			Utils\wp_register_unused_sidebar();
 		}
 
-		$formatter = new Formatter( $assoc_args, $this->fields );
+		$sidebars = $wp_registered_sidebars;
+
+		if ( isset( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
+			WP_CLI::line( implode( ' ', wp_list_pluck( $sidebars, 'id' ) ) );
+			return;
+		}
+
+		if ( isset( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {
+			WP_CLI::line( count( $sidebars ) );
+			return;
+		}
+
+		$formatter = new Formatter( $assoc_args, $this->default_fields );
 		$formatter->display_items( $sidebars );
+	}
+
+	/**
+	 * Get details about a specific sidebar.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The sidebar ID.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific object fields.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp sidebar get sidebar-1
+	 *     $ wp sidebar get wp_inactive_widgets --format=json
+	 *
+	 * @when after_wp_load
+	 */
+	public function get( $args, $assoc_args ) {
+		global $wp_registered_sidebars;
+
+		$id = $args[0];
+
+		if ( ! isset( $wp_registered_sidebars[ $id ] ) ) {
+			WP_CLI::error( "Sidebar '{$id}' does not exist." );
+		}
+
+		$formatter = new Formatter( $assoc_args, $this->default_fields );
+		$formatter->display_item( $wp_registered_sidebars[ $id ] );
+	}
+
+	/**
+	 * Check if a sidebar exists.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The sidebar ID.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp sidebar exists sidebar-1
+	 *     $ wp sidebar exists foo && echo "exists"
+	 *
+	 * @when after_wp_load
+	 */
+	public function exists( $args ) {
+		global $wp_registered_sidebars;
+
+		if ( isset( $wp_registered_sidebars[ $args[0] ] ) ) {
+			WP_CLI::halt( 0 );
+		}
+
+		WP_CLI::halt( 1 );
+	}
+
+	/**
+	 * List widgets assigned to a sidebar.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The sidebar ID.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - ids
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp sidebar widgets sidebar-1
+	 *     $ wp sidebar widgets wp_inactive_widgets --format=ids
+	 *
+	 * @when after_wp_load
+	 */
+	public function widgets( $args, $assoc_args ) {
+		global $wp_registered_sidebars;
+
+		$id = $args[0];
+
+		if ( ! isset( $wp_registered_sidebars[ $id ] ) ) {
+			WP_CLI::error( "Sidebar '{$id}' does not exist." );
+		}
+
+		$sidebars_widgets = wp_get_sidebars_widgets();
+		$widgets          = isset( $sidebars_widgets[ $id ] ) ? $sidebars_widgets[ $id ] : [];
+
+		if ( empty( $widgets ) ) {
+			WP_CLI::warning( "No widgets found in sidebar '{$id}'." );
+			return;
+		}
+
+		if ( isset( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
+			WP_CLI::line( implode( ' ', $widgets ) );
+			return;
+		}
+
+		$items = array_map(
+			function ( $widget_id ) {
+				return [ 'id' => $widget_id ];
+			},
+			$widgets
+		);
+
+		$formatter = new Formatter( $assoc_args, [ 'id' ] );
+		$formatter->display_items( $items );
 	}
 }

--- a/src/Sidebar_Command.php
+++ b/src/Sidebar_Command.php
@@ -43,6 +43,22 @@ class Sidebar_Command extends WP_CLI_Command {
 	 *   - count
 	 * ---
 	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * These fields will be displayed by default for each sidebar:
+	 *
+	 * * name
+	 * * id
+	 * * description
+	 *
+	 * These fields are optionally available:
+	 *
+	 * * class
+	 * * before_widget
+	 * * after_widget
+	 * * before_title
+	 * * after_title
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp sidebar list
@@ -107,6 +123,10 @@ class Sidebar_Command extends WP_CLI_Command {
 	public function get( $args, $assoc_args ) {
 		global $wp_registered_sidebars;
 
+		if ( function_exists( 'wp_register_unused_sidebar' ) ) {
+			Utils\wp_register_unused_sidebar();
+		}
+
 		$id = $args[0];
 
 		if ( ! isset( $wp_registered_sidebars[ $id ] ) ) {
@@ -128,12 +148,16 @@ class Sidebar_Command extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 *     $ wp sidebar exists sidebar-1
-	 *     $ wp sidebar exists foo && echo "exists"
+	 *     $ wp sidebar exists wp_inactive_widgets && echo "exists"
 	 *
 	 * @when after_wp_load
 	 */
 	public function exists( $args ) {
 		global $wp_registered_sidebars;
+
+		if ( function_exists( 'wp_register_unused_sidebar' ) ) {
+			Utils\wp_register_unused_sidebar();
+		}
 
 		if ( isset( $wp_registered_sidebars[ $args[0] ] ) ) {
 			WP_CLI::halt( 0 );
@@ -172,6 +196,10 @@ class Sidebar_Command extends WP_CLI_Command {
 	public function widgets( $args, $assoc_args ) {
 		global $wp_registered_sidebars;
 
+		if ( function_exists( 'wp_register_unused_sidebar' ) ) {
+			Utils\wp_register_unused_sidebar();
+		}
+
 		$id = $args[0];
 
 		if ( ! isset( $wp_registered_sidebars[ $id ] ) ) {
@@ -179,15 +207,15 @@ class Sidebar_Command extends WP_CLI_Command {
 		}
 
 		$sidebars_widgets = wp_get_sidebars_widgets();
-		$widgets          = isset( $sidebars_widgets[ $id ] ) ? $sidebars_widgets[ $id ] : [];
+		$widget_ids       = isset( $sidebars_widgets[ $id ] ) ? $sidebars_widgets[ $id ] : [];
 
-		if ( empty( $widgets ) ) {
+		if ( empty( $widget_ids ) ) {
 			WP_CLI::warning( "No widgets found in sidebar '{$id}'." );
 			return;
 		}
 
 		if ( isset( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
-			WP_CLI::line( implode( ' ', $widgets ) );
+			WP_CLI::line( implode( ' ', $widget_ids ) );
 			return;
 		}
 
@@ -195,7 +223,7 @@ class Sidebar_Command extends WP_CLI_Command {
 			function ( $widget_id ) {
 				return [ 'id' => $widget_id ];
 			},
-			$widgets
+			$widget_ids
 		);
 
 		$formatter = new Formatter( $assoc_args, [ 'id' ] );

--- a/src/Sidebar_Command.php
+++ b/src/Sidebar_Command.php
@@ -76,7 +76,13 @@ class Sidebar_Command extends WP_CLI_Command {
 			Utils\wp_register_unused_sidebar();
 		}
 
-		$sidebars = $wp_registered_sidebars;
+		// Filter out wp_inactive_widgets from the display
+		$sidebars = array_filter(
+			$wp_registered_sidebars,
+			function( $sidebar ) {
+				return 'wp_inactive_widgets' !== $sidebar['id'];
+			}
+		);
 
 		if ( isset( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
 			WP_CLI::line( implode( ' ', wp_list_pluck( $sidebars, 'id' ) ) );


### PR DESCRIPTION
## Description

This PR extends the `wp sidebar` command with additional subcommands to make sidebar management more complete and consistent with other WP-CLI commands.

### New subcommands added

- `wp sidebar get <id>`  
  Retrieve details for a specific registered sidebar.

- `wp sidebar exists <id>`  
  Check whether a sidebar exists (returns appropriate exit codes).

- `wp sidebar widgets <id>`  
  List widgets assigned to a given sidebar.